### PR TITLE
Update regexp for memory allocation

### DIFF
--- a/linux/datashare.sh
+++ b/linux/datashare.sh
@@ -7,7 +7,7 @@ elasticsearch_image=docker.elastic.co/elasticsearch/elasticsearch:7.9.1
 DATASHARE_HOME="${HOME}"/.local/share/datashare
 mkdir -p "${DATASHARE_HOME}"/dist "${DATASHARE_HOME}"/index "${DATASHARE_HOME}"/plugins "${DATASHARE_HOME}"/extensions "${HOME}"/Datashare
 
-MEM_ALLOCATED_MEGA=$(free|awk '/^Mem:/{print $2"/(2*1024)"}'|bc)
+MEM_ALLOCATED_MEGA=$(LC_ALL=C free|awk '/^M[^:]+:/{print $2"/(2*1024)"}'|bc)
 BIND_HOST=127.0.0.1
 
 if [ -z "${DS_JAVA_OPTS}" ] && [ -n "${MEM_ALLOCATED_MEGA}" ]; then


### PR DESCRIPTION
The expression used assumed that the displayed line of the free memory starts with `Mem:`. This may NOT be happening in systems which are not in English. A workaround has been applied to grab only the line starting by `M` to fit outputs like:

```
$ free
              total       usado       libre  compartido búfer/caché  disponible
Memoria:    15656840     5287600     2484232     1300908     7885008     8787620
Swap:       1003516           0     1003516
```

Thus, the calculation can be performed:

```
$ free|awk '/^M[^:]+:/{print $2"/(2*1024)"}' | bc
7644
```