### PR TITLE
chore: prevent terminal from closing after ended process

### DIFF
--- a/windows/datashare.bat
+++ b/windows/datashare.bat
@@ -15,3 +15,4 @@ java -cp "dist;\Program Files\Datashare\datashare-dist-${VERSION}-all.jar" ^
   --elasticsearchDataPath "%APPDATA%"\Datashare\index ^
   --pluginsDir "%APPDATA%"\Datashare\plugins ^
   --extensionsDir "%APPDATA%"\Datashare\extensions
+pause


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
This commit aims to make the debugging easier on Windows. When an error happens, the executable often closes very quickly and the user can't see the logs.

**Solution**
When the current process is done, a key has to be pressed to close the window