### PR TITLE
feat: java 11 check and install

### DIFF
--- a/windows/datashare.bat
+++ b/windows/datashare.bat
@@ -1,7 +1,9 @@
 @echo off
 
 cd "%APPDATA%"\Datashare
-java -cp "dist;\Program Files\Datashare\datashare-dist-${VERSION}-all.jar" ^
+set jre_version=11
+FOR /F "tokens=*" %%i IN ('where -f java ^| findstr -R "[jdk|jre]-%jre_version%" ^|  cmd /e /v /q /c"set/p.=&&echo(^!.^!"') do SET java_exe=%%i
+%java_exe% -cp "dist;\Program Files\Datashare\datashare-dist-${VERSION}-all.jar" ^
   -DPROD_MODE=true -Dfile.encoding=UTF-8 ^
   -Djava.system.class.loader=org.icij.datashare.DynamicClassLoader org.icij.datashare.Main ^
   --dataDir "%APPDATA%"\Datashare\data ^

--- a/windows/datashare.nsi
+++ b/windows/datashare.nsi
@@ -127,12 +127,12 @@ FunctionEnd
 
 Function InstallOpenJre64
     #Java lib test
-    nsExec::ExecToStack "java -version"
+    nsExec::ExecToStack '"$SYSDIR\cmd.exe" /c where -f java | findstr -R "[jdk|jre]-11" | cmd /e /v /q /c"set/p.=&&echo(^!.^!"'
     Pop $0
     Pop $1
-    StrCmp $0 "0" JavaFound JavaMissing
+    StrCmp $1 "" JavaMissing JavaFound
     JavaMissing:
-        DetailPrint "Downloading JRE 11 from: ${OPEN_JRE_64_DOWNLOAD_URL}"
+        DetailPrint "Downloading OpenJRE 11 from: ${OPEN_JRE_64_DOWNLOAD_URL}"
         inetc::get "${OPEN_JRE_64_DOWNLOAD_URL}" "${OPEN_JRE_64_PATH}" /end
         Pop $0
         DetailPrint "Download Status: $0"
@@ -140,11 +140,11 @@ Function InstallOpenJre64
             DetailPrint "Download Failed: $0"
             Abort
         ${EndIf}
-        DetailPrint "Installing OpenJRE 8"
+        DetailPrint "Installing OpenJRE 11"
         ExecWait 'msiexec.exe /i "${OPEN_JRE_64_PATH}" /QN /L*V "$TEMP\msilog.log"'
         Goto JavaDone
     JavaFound:
-        DetailPrint "JRE already installed, version : $1"
+        DetailPrint "Java 11 already installed"
     JavaDone:
 FunctionEnd
 


### PR DESCRIPTION
**The issue**
So far the windows installer used to check if java was installed with `java -version` command. The problem with this command is the fact it doesn't check if the installed version of Java is compatible with Datashare and it can lead to errors at launch for some users.

**Solution**
This PR does two things : 
- [During installation] Adds a verification that checks if any compatible version of Java (currently Java 11) is installed, if not installs it
- Change the launching script that use explicit Java 11 exe to start Datashare (using `java` command is not enough in case we have multiple Java version installed, it will pick the one used by default which is not necessarily Java 11)