### PR TITLE
fix: windows installer java error

### DIFF
--- a/windows/datashare.bat
+++ b/windows/datashare.bat
@@ -1,8 +1,7 @@
 @echo off
 
 cd "%APPDATA%"\Datashare
-set jre_version=11
-FOR /F "tokens=*" %%i IN ('where -f java ^| findstr -R "[jdk|jre]-%jre_version%" ^|  cmd /e /v /q /c"set/p.=&&echo(^!.^!"') do SET java_exe=%%i
+FOR /F "tokens=*" %%i IN ('where -f java ^| findstr -R "[jdk|jre]-" ^| findstr -R -v "[jdk|jre]-[0-9]\. [jdk|jre]-10" ^| cmd /e /v /q /c"set/p.=&&echo(^!.^!"') do SET java_exe=%%i
 %java_exe% -cp "dist;\Program Files\Datashare\datashare-dist-${VERSION}-all.jar" ^
   --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED ^
   -DPROD_MODE=true -Dfile.encoding=UTF-8 ^

--- a/windows/datashare.nsi
+++ b/windows/datashare.nsi
@@ -127,10 +127,12 @@ FunctionEnd
 
 Function InstallOpenJre64
     #Java lib test
-    nsExec::ExecToStack '"$SYSDIR\cmd.exe" /c where -f java | findstr -R "[jdk|jre]-11" | cmd /e /v /q /c"set/p.=&&echo(^!.^!"'
+    nsExec::ExecToStack '"$SYSDIR\cmd.exe" /c where -f java | findstr -R "[jdk|jre]-" | findstr -R -v "[jdk|jre]-[0-9]\. [jdk|jre]-10"'
     Pop $0
     Pop $1
-    StrCmp $1 "" JavaMissing JavaFound
+    DetailPrint "Dollar 0 : $0"
+    DetailPrint "Dollar 1 : $1"
+    StrCmp $0 1 JavaMissing JavaFound
     JavaMissing:
         DetailPrint "Downloading OpenJRE 11 from: ${OPEN_JRE_64_DOWNLOAD_URL}"
         inetc::get "${OPEN_JRE_64_DOWNLOAD_URL}" "${OPEN_JRE_64_PATH}" /end
@@ -144,7 +146,7 @@ Function InstallOpenJre64
         ExecWait 'msiexec.exe /i "${OPEN_JRE_64_PATH}" /QN /L*V "$TEMP\msilog.log"'
         Goto JavaDone
     JavaFound:
-        DetailPrint "Java 11 already installed"
+        DetailPrint "Java already installed"
     JavaDone:
 FunctionEnd
 

--- a/windows/datashare.nsi
+++ b/windows/datashare.nsi
@@ -130,8 +130,6 @@ Function InstallOpenJre64
     nsExec::ExecToStack '"$SYSDIR\cmd.exe" /c where -f java | findstr -R "[jdk|jre]-" | findstr -R -v "[jdk|jre]-[0-9]\. [jdk|jre]-10"'
     Pop $0
     Pop $1
-    DetailPrint "Dollar 0 : $0"
-    DetailPrint "Dollar 1 : $1"
     StrCmp $0 1 JavaMissing JavaFound
     JavaMissing:
         DetailPrint "Downloading OpenJRE 11 from: ${OPEN_JRE_64_DOWNLOAD_URL}"


### PR DESCRIPTION
**Description of the problem**
On windows installer, when any version of java were installed, Datashare installer wouldn't install Java 11.
The element tested for this condition was wrong.

**Goal**
This PR fixes this condition. Additionally following [this PR](https://github.com/ICIJ/datashare/pull/1084), we installer now checks if Java version 11 and above are installed during DS installation. Besides, the launching script of DS will choose any compatible java version to use to launch DS