### PR TITLE
feature: create `datashare` CLI on macOS

### DIFF
--- a/mac/scripts/postinstall
+++ b/mac/scripts/postinstall
@@ -34,9 +34,11 @@ create_datashare_cli () {
         sudo ln -s /Applications/Datashare.app/Contents/MacOS/Datashare.command /usr/local/bin/datashare
         if [ $? -ne 0 ]; then
             log_error "Unable to create Datashare CLI"
-            return 1
+            # TODO: uncomment this to exit here in case of failure
+#            return 1
+        else
+            log_info 'Successfully create datashare CLI'
         fi
-        log_info 'Successfully create datashare CLI'
     fi
 }
 

--- a/mac/scripts/postinstall
+++ b/mac/scripts/postinstall
@@ -8,14 +8,14 @@ ds_jar_url=https://github.com/ICIJ/datashare/releases/download/$ds_version/$ds_j
 
 log_error () {
   # This function takes a single argument, which is the message to log.
-  # The logger command is used to log the message to the install facility 
+  # The logger command is used to log the message to the install facility
   # at the error level.
   logger -t DatashareInstaller -p install.error "$1"
 }
 
 log_info () {
   # This function takes a single argument, which is the message to log.
-  # The logger command is used to log the message to the install facility 
+  # The logger command is used to log the message to the install facility
   # at the info level.
   logger -t DatashareInstaller -p install.info "$1"
 }
@@ -27,6 +27,17 @@ is_datashare_installed () {
   fi
 
   log_info "Datashare $ds_version is already installed."
+}
+
+create_datashare_cli () {
+    if ! command -v datashare 1>/dev/null 2>&1 ; then
+        sudo ln -s /Applications/Datashare.app/Contents/MacOS/Datashare.command /usr/local/bin/datashare
+        if [ $? -ne 0 ]; then
+            log_error "Unable to create Datashare CLI"
+            return 1
+        fi
+        log_info 'Successfully create datashare CLI'
+    fi
 }
 
 download_datashare () {
@@ -59,3 +70,5 @@ if ! is_datashare_installed && ! download_datashare ; then
 fi
 # Finally, setup user directories
 setup_user_directories
+# When everything is done, we create the datashare CLI if it doesn't exist yet
+create_datashare_cli


### PR DESCRIPTION
# TODO
- [x] handle forwarding args from the `datashare` CLI to the JAR in a similar way as in the `launchBack.sh` of DS or `entrypoint.sh` of the docker image. (done in #15 )

# Changes

## `mac`
### Added
- create `datashare` CLI by creating a symlink if the command does not exists yet