### PR TITLE
build(start): use the new "app start" subcommand

### DIFF
--- a/mac/start.sh
+++ b/mac/start.sh
@@ -62,6 +62,7 @@ function start_datashare {
 
 function start_datashare_with_defaults {
     local default_params=(
+      app start
       --dataDir "$datashare_data_path"
       --queueType MEMORY
       --busType MEMORY

--- a/windows/datashare.bat
+++ b/windows/datashare.bat
@@ -21,6 +21,7 @@ set DS_JAVA_OPTS=%DS_JAVA_OPTS% --add-opens java.base/java.lang=ALL-UNNAMED --ad
 
 %java_exe% -cp "dist;%CURRENT_DIR%\datashare-dist-${VERSION}-all.jar" ^
   %DS_JAVA_OPTS% org.icij.datashare.Main ^
+  app start ^
   --dataDir "%CURRENT_DIR%"\data ^
   --batchQueueType MEMORY ^
   --queueType MEMORY ^


### PR DESCRIPTION
Even though the new subcommand architecture is retro-compatible, this change use the new "app serve" subcommand on Macos and Windows launcher.